### PR TITLE
Add ClawCloud Run Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This is a personal Anki server, which you can sync against instead of AnkiWeb.
 
 [![](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3Danki-sync-server)
 
+## Deploying on ClawCloudRun
+
+[![](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=97A72IAPCMPQ&openapp=system-fastdeploy%3FtemplateName%3Danki-sync-server)
+
 ## Deploying with Docker
 
 ```bash


### PR DESCRIPTION
docs: add ClawCloud Run button

---
We are **ClawCloud Run** — a cloud-native deployment platform where users can deploy your application with one click. The referral code in the deployment link is only for anonymous traffic analytics to help us improve our platform. If you’d like to use your own code, simply sign up on ClawCloud Run and replace it in seconds.